### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An intelligent MCP server that restarts Claude's MCP handler process without disrupting the UI. Unlike traditional restart tools that kill the entire Claude Desktop application, this tool surgically restarts only the Node.js process handling MCP connections, allowing for seamless plugin reloading.
 
+<a href="https://glama.ai/mcp/servers/@199-biotechnologies/mcp-autostarter">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@199-biotechnologies/mcp-autostarter/badge" alt="Autostarter MCP server" />
+</a>
+
 ## Why MCP Autostarter?
 
 When developing or installing MCP plugins, you need to restart Claude to load new configurations. Traditional approaches kill the entire Claude Desktop app, disrupting your workflow. MCP Autostarter is smarter - it:


### PR DESCRIPTION
This PR adds a badge for the [MCP Autostarter](https://glama.ai/mcp/servers/@199-biotechnologies/mcp-autostarter) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@199-biotechnologies/mcp-autostarter">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@199-biotechnologies/mcp-autostarter/badge" alt="Autostarter MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.